### PR TITLE
[docs] Added file naming schema to notebooks and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ python src/viirs.py --help
 
 **Note: All three interfaces will store the downloaded and processed products in the previously configured directories. You may export these for use in other applications such as QGIS or ArcGIS.**
 
+# Product naming conventions
+Once products have been downloaded, it is advised to keep the given naming conventions to maintain [data provenance](https://ardc.edu.au/resource/data-provenance/).  
+To assist in this:  
+ - Sentinel 2 and Landsat naming conventions can be found [here](https://knowledge.dea.ga.gov.au/guides/reference/collection_3_naming/).  
+ - VIIRS naming conventions can be found [here](https://lpdaac.usgs.gov/data/get-started-data/collection-overview/missions/s-npp-nasa-viirs-overview/#viirs-naming-conventions).  
+
 
 # Additional Notes
 1. Sentinel Australasia Region Access (SARA) is undertaking major upgrades to migrate to the new Copernicus Data Space Ecosystem (CDSE) platform from October 2023 to Mid 2024. Data access may be disrupted, with changes on how to access data during this period. It is hoped that Digital Earth Australia will account for this major change and their STAC API will remain accessible.

--- a/landsat.ipynb
+++ b/landsat.ipynb
@@ -177,7 +177,12 @@
     "\n",
     "Please confirm your search results above. Depending on your search criteria, there may be a large number of products to download. \n",
     "\n",
-    "Please be patient."
+    "Please be patient.\n",
+    "\n",
+    "The filenames of downloaded Level 2 products have the follow naming convention (described in more detail [here](https://knowledge.dea.ga.gov.au/guides/reference/collection_3_naming/)).\n",
+    "\n",
+    "![image](notebook_images/ARD_Landsat_Filename.svg)  \n",
+    "Image © Commonwealth of Australia (Geoscience Australia) 2021, [Digital Earth Austraia](https://knowledge.dea.ga.gov.au/guides/reference/collection_3_naming/), [CC BY 4.0](https://www.ga.gov.au/copyright)"
    ]
   },
   {

--- a/sentinel_2.ipynb
+++ b/sentinel_2.ipynb
@@ -176,7 +176,12 @@
     "\n",
     "Please confirm your search results above. Depending on your search criteria, there may be a large number of products to download. \n",
     "\n",
-    "Please be patient."
+    "Please be patient.\n",
+    "\n",
+    "The filenames of downloaded Level 2 products have the follow naming convention (described in more detail [here](https://knowledge.dea.ga.gov.au/guides/reference/collection_3_naming/)).\n",
+    "\n",
+    "![image](notebook_images/ARD_S-2_Filename.svg)  \n",
+    "Image © Commonwealth of Australia (Geoscience Australia) 2021, [Digital Earth Austraia](https://knowledge.dea.ga.gov.au/guides/reference/collection_3_naming/), [CC BY 4.0](https://www.ga.gov.au/copyright)"
    ]
   },
   {

--- a/viirs.ipynb
+++ b/viirs.ipynb
@@ -160,7 +160,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Depending on your search parameters, APPEEARS may take a while to process your request."
+    "Depending on your search parameters, APPEEARS may take a while to process your request.\n",
+    "\n",
+    "More information on VIIRS filenames can be found [here](https://lpdaac.usgs.gov/data/get-started-data/collection-overview/missions/s-npp-nasa-viirs-overview/)."
    ]
   },
   {


### PR DESCRIPTION
Fixes Issue https://github.com/AustralianSDAF/EoAF/issues/7

- Adds file explanations of the GA products to notebooks using images from https://knowledge.dea.ga.gov.au/guides/reference/collection_3_naming/
- adds a link to VIIRS file naming conventions
- adds some info & links to the readme file